### PR TITLE
Add custom fields to search in the dashboard

### DIFF
--- a/src/components/AgentTable.vue
+++ b/src/components/AgentTable.vue
@@ -373,6 +373,7 @@ export default {
         "local_ips",
         "make_model",
         "physical_disks",
+        "custom_fields"
       ];
       // quasar filter only does visible columns so this is a hack to add hidden columns we want to filter
       // originally I was modifying cols directly but this led to phantom colum so doing it this way now
@@ -432,7 +433,11 @@ export default {
 
         // Normal text filter
         return allColumns.some((col) => {
-          const val = cellValue(col, row) + "";
+          let valObj = cellValue(col, row);
+          if (Array.isArray(valObj)) {
+            valObj = valObj.map((item) => item.value ? item.value : item);
+          }
+          const val = valObj + "";
           const haystack =
             val === "undefined" || val === "null" ? "" : val.toLowerCase();
           return haystack.indexOf(search) !== -1;

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -452,7 +452,7 @@ export default {
       showInstallAgentModal: false,
       sitePk: null,
       innerModel: (this.$q.screen.height - 82) / 2,
-      search: "",
+      search: (this.$route.query.search ? this.$route.query.search : ""),
       filterTextLength: 0,
       filterAvailability: "all",
       filterPatchesPending: false,


### PR DESCRIPTION
Add custom fields to search in the dashboard, in our company we will use the custom fields to store Asset Number and current responsible for the equipment, among other information. 

Will be useful to be able to search by those fields.


Require the API changes: https://github.com/amidaware/tacticalrmm/pull/1468