### PR TITLE
[Feature] Add cross site scripting

### DIFF
--- a/src/components/scripts/ScriptFormModal.vue
+++ b/src/components/scripts/ScriptFormModal.vue
@@ -298,6 +298,8 @@ const lang = computed(() => {
   else if (script.shell === "powershell") return "powershell";
   else if (script.shell === "python") return "python";
   else if (script.shell === "shell") return "shell";
+  else if (script.shell === "nushell") return "nushell";
+  else if (script.shell === "deno") return "typescript";
   else return "";
 });
 

--- a/src/components/scripts/ScriptManager.vue
+++ b/src/components/scripts/ScriptManager.vue
@@ -175,6 +175,20 @@
               >
                 <q-tooltip> Shell </q-tooltip>
               </q-icon>
+              <q-icon
+                v-else-if="props.node.shell === 'nushell'"
+                name="mdi-code-greater-than"
+                color="primary"
+              >
+                <q-tooltip> Nushell </q-tooltip>
+              </q-icon>
+              <q-icon
+                v-else-if="props.node.shell === 'deno'"
+                name="mdi-language-typescript"
+                color="primary"
+              >
+                <q-tooltip> Deno </q-tooltip>
+              </q-icon>
 
               <span
                 class="q-pl-xs text-weight-bold"
@@ -462,6 +476,22 @@
                 color="primary"
               >
                 <q-tooltip> Shell </q-tooltip>
+              </q-icon>
+              <q-icon
+                v-else-if="props.row.shell === 'nushell'"
+                size="sm"
+                name="mdi-code-greater-than"
+                color="primary"
+              >
+                <q-tooltip> Nushell </q-tooltip>
+              </q-icon>
+              <q-icon
+                v-else-if="props.row.shell === 'deno'"
+                size="sm"
+                name="mdi-language-typescript"
+                color="primary"
+              >
+                <q-tooltip> Deno </q-tooltip>
               </q-icon>
             </q-td>
             <!-- supported platforms -->

--- a/src/components/scripts/ScriptSnippets.vue
+++ b/src/components/scripts/ScriptSnippets.vue
@@ -124,6 +124,22 @@
               >
                 <q-tooltip> Shell </q-tooltip>
               </q-icon>
+              <q-icon
+                v-else-if="props.row.shell === 'nushell'"
+                name="mdi-nushell"
+                color="primary"
+                size="sm"
+              >
+                <q-tooltip> Nushell </q-tooltip>
+              </q-icon>
+              <q-icon
+                v-else-if="props.row.shell === 'deno'"
+                name="mdi-typescript"
+                color="primary"
+                size="sm"
+              >
+                <q-tooltip> Deno </q-tooltip>
+              </q-icon>
             </q-td>
             <!-- name -->
             <q-td>{{ props.row.name }}</q-td>

--- a/src/composables/scripts.js
+++ b/src/composables/scripts.js
@@ -65,4 +65,6 @@ export const shellOptions = [
   { label: "Batch", value: "cmd" },
   { label: "Python", value: "python" },
   { label: "Shell", value: "shell" },
+  { label: "Nushell", value: "nushell" },
+  { label: "Deno", value: "deno" },
 ];

--- a/src/types/scripts.ts
+++ b/src/types/scripts.ts
@@ -1,6 +1,6 @@
 import type { AgentPlatformType } from "@/types/agents";
 
-export type ScriptShellType = "powershell" | "cmd" | "shell" | "python";
+export type ScriptShellType = "powershell" | "cmd" | "shell" | "python" | "nushell" | "deno";
 
 export interface Script {
   id?: number;


### PR DESCRIPTION
This PR adds support for [Nushell](https://www.nushell.sh/) and [Deno](https://deno.land/) to provide a cross platform scripting environments.

# Associated PRs

- rmmagent: amidaware/rmmagent#38
- tacticalrmm: amidaware/tacticalrmm#1676
- tacticalrmm-web: amidaware/tacticalrmm-web#14
- trmm-docs: amidaware/trmm-docs#217
- community-scripts: TBD

# Questions

- What tests are needed?