### PR TITLE
Fix: First time developer setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,5 +2,13 @@ PROD_URL = "https://api.example.com"
 DEV_URL = "https://api.example.com"
 APP_URL = "https://app.example.com"
 DEV_HOST = 0.0.0.0
+
+# This needs to match APP_PORT in tacticalrmm/.devcontainer/.env
+# tacticalrmm/.devcontainer/.env.example uses 443
 DEV_PORT = 80
+
 USE_HTTPS = false
+
+# Without this, Vue throws a "DOMException: The operation is insecure" error when because it's using ws://, not wss://
+# An alternative is to set "network.websocket.allowInsecureFromHTTPS = true" in Firefox.
+DOCKER_BUILD = true

--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ DEV_PORT = 80
 
 USE_HTTPS = false
 
-# Without this, Vue throws a "DOMException: The operation is insecure" error when because it's using ws://, not wss://
+# Vue throws a "DOMException: The operation is insecure" error when HTTPS is used on the frontend because it's using
+# ws://. Setting DOCKER_BUILD causes Vue to use wss:// which solved the problem.
 # An alternative is to set "network.websocket.allowInsecureFromHTTPS = true" in Firefox.
 DOCKER_BUILD = true


### PR DESCRIPTION
While setting up the dev environment for the first time, I ran into some issues. This PR fixes `.env.example` to help future developers.

1. The nginx container uses port 443 which is coming from `DEV_PORT` in `tacticalrmm/.devcontainer/.env`. These need to match.
2. Vue was throwing a "_DOMException: The operation is insecure_" error because it's using `ws://`. Adding `DOCKER_BUILD` causes Vue to use `wss://`, solving the problem.