### PR TITLE
Fixed sorting order of agentstatus in the dashboard and alert severity in the alert overview

### DIFF
--- a/src/components/modals/alerts/AlertsOverview.vue
+++ b/src/components/modals/alerts/AlertsOverview.vue
@@ -283,6 +283,14 @@ export default {
           label: "Severity",
           field: "severity",
           align: "left",
+          sort: (a, b) => {
+            const severityRank = {
+              error: 0,
+              warning: 1,
+              info: 2,
+            };
+            return (severityRank[a] ?? 3) - (severityRank[b] ?? 3);
+          },
           sortable: true,
         },
         {

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -587,6 +587,14 @@ export default {
           name: "agentstatus",
           field: "status",
           align: "left",
+          sort: (a, b) => {
+            const statusRank = {
+              online: 0,
+              offline: 1,
+              overdue: 2,
+            };
+            return (statusRank[a] ?? 3) - (statusRank[b] ?? 3);
+          },
           sortable: true,
         },
         {


### PR DESCRIPTION
Before it was sorted wrong:
<img width="1884" height="498" alt="image" src="https://github.com/user-attachments/assets/6dc14367-f360-463e-8ee9-df229f261a6c" />
<img width="1568" height="588" alt="image" src="https://github.com/user-attachments/assets/75089958-0f7d-4d8d-a065-646b4374bc0f" />


New sorting order of alerts in the alerts overview:
<img width="1907" height="860" alt="image" src="https://github.com/user-attachments/assets/d364968e-7b9f-4481-8065-a7af4189a9b1" />
New sorting order of agents in the dashboard:
<img width="1584" height="424" alt="image" src="https://github.com/user-attachments/assets/2e6a5974-3ae1-493d-a6fd-d514425a3226" />
