### PR TITLE
Change alert template re-alert interval from days to minutes

### DIFF
--- a/src/api/accounts.js
+++ b/src/api/accounts.js
@@ -108,3 +108,28 @@ export async function removeAPIKey(id) {
   const { data } = await axios.delete(`${baseUrl}/apikeys/${id}/`);
   return data;
 }
+
+// ssh key api functions
+export async function fetchSSHKeys(params = {}) {
+  try {
+    const { data } = await axios.get(`${baseUrl}/sshkeys/`, { params: params });
+    return data;
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+export async function saveSSHKey(sshKey) {
+  const { data } = await axios.post(`${baseUrl}/sshkeys/`, sshKey);
+  return data;
+}
+
+export async function editSSHKey(id, sshKey) {
+  const { data } = await axios.put(`${baseUrl}/sshkeys/${id}/`, sshKey);
+  return data;
+}
+
+export async function removeSSHKey(id) {
+  const { data } = await axios.delete(`${baseUrl}/sshkeys/${id}/`);
+  return data;
+}

--- a/src/components/core/SSHKeysForm.vue
+++ b/src/components/core/SSHKeysForm.vue
@@ -1,0 +1,114 @@
+<template>
+  <q-dialog ref="dialogRef" @hide="onDialogHide">
+    <q-card class="q-dialog-plugin" style="width: 60vw">
+      <q-bar>
+        {{ title }}
+        <q-space />
+        <q-btn dense flat icon="close" v-close-popup>
+          <q-tooltip class="bg-white text-primary">Close</q-tooltip>
+        </q-btn>
+      </q-bar>
+      <q-form @submit.prevent="submitForm">
+        <q-card-section>
+          <span v-if="!SSHKey">Add a public key for SSH access to agents</span>
+        </q-card-section>
+
+        <q-card-section>
+          <q-input
+            label="Name"
+            outlined
+            dense
+            v-model="localKey.name"
+            :rules="[(val) => !!val || '*Required']"
+          />
+        </q-card-section>
+
+        <q-card-section v-if="!SSHKey">
+          <q-input
+            label="Public Key"
+            outlined
+            dense
+            type="textarea"
+            v-model="localKey.public_key"
+            :rules="[(val) => !!val || '*Required']"
+            placeholder="ssh-ed25519 AAAAC3... your@email.com"
+          />
+        </q-card-section>
+
+        <q-card-section v-if="SSHKey">
+          <q-input
+            label="Comment"
+            outlined
+            dense
+            v-model="localKey.comment"
+          />
+        </q-card-section>
+
+        <q-card-actions align="right">
+          <q-btn flat label="Cancel" v-close-popup />
+          <q-btn
+            flat
+            label="Submit"
+            color="primary"
+            type="submit"
+            :loading="loading"
+          />
+        </q-card-actions>
+      </q-form>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script>
+import { ref, computed } from "vue";
+import { useDialogPluginComponent } from "quasar";
+import { saveSSHKey, editSSHKey } from "@/api/accounts";
+import { notifySuccess } from "@/utils/notify";
+
+export default {
+  name: "SSHKeysForm",
+  emits: [...useDialogPluginComponent.emits],
+  props: { SSHKey: Object },
+  setup(props) {
+    const { dialogRef, onDialogHide, onDialogOK } = useDialogPluginComponent();
+
+    const key = props.SSHKey
+      ? ref(Object.assign({}, props.SSHKey))
+      : ref({ name: "", public_key: "" });
+    const loading = ref(false);
+
+    const title = computed(() =>
+      props.SSHKey ? "Edit SSH Key" : "Add SSH Key"
+    );
+
+    async function submitForm() {
+      loading.value = true;
+
+      const data = {
+        ...key.value,
+      };
+
+      try {
+        const result = props.SSHKey
+          ? await editSSHKey(data.id, data)
+          : await saveSSHKey(data);
+        onDialogOK();
+        notifySuccess(result);
+        loading.value = false;
+      } catch (e) {
+        loading.value = false;
+      }
+    }
+
+    return {
+      localKey: key,
+      loading,
+      title,
+      submitForm,
+      dialogRef,
+      onDialogHide,
+      onDialogOK,
+    };
+  },
+};
+</script>

--- a/src/components/core/SSHKeysTable.vue
+++ b/src/components/core/SSHKeysTable.vue
@@ -1,0 +1,203 @@
+<template>
+  <div>
+    <div class="row">
+      <div class="text-subtitle2">SSH Keys</div>
+      <q-space />
+      <q-btn
+        size="sm"
+        color="grey-5"
+        icon="fas fa-plus"
+        text-color="black"
+        label="Add key"
+        @click="addSSHKey"
+      />
+    </div>
+    <q-separator />
+    <q-table
+      dense
+      :rows="keys"
+      :columns="columns"
+      v-model:pagination="pagination"
+      row-key="id"
+      binary-state-sort
+      hide-pagination
+      virtual-scroll
+      :rows-per-page-options="[0]"
+      no-data-label="No SSH keys added yet"
+    >
+      <template v-slot:header-cell-actions="props">
+        <q-th :props="props" auto-width> </q-th>
+      </template>
+
+      <template v-slot:body="props">
+        <q-tr
+          :props="props"
+          class="cursor-pointer"
+          @dblclick="editSSHKey(props.row)"
+        >
+          <q-menu context-menu>
+            <q-list dense style="min-width: 200px">
+              <q-item clickable v-close-popup @click="editSSHKey(props.row)">
+                <q-item-section side>
+                  <q-icon name="edit" />
+                </q-item-section>
+                <q-item-section>Edit</q-item-section>
+              </q-item>
+              <q-item clickable v-close-popup @click="deleteSSHKey(props.row)">
+                <q-item-section side>
+                  <q-icon name="delete" />
+                </q-item-section>
+                <q-item-section>Delete</q-item-section>
+              </q-item>
+
+              <q-separator></q-separator>
+
+              <q-item clickable v-close-popup>
+                <q-item-section>Close</q-item-section>
+              </q-item>
+            </q-list>
+          </q-menu>
+          <q-td>
+            {{ props.row.name }}
+          </q-td>
+          <q-td>
+            {{ props.row.key_type }}
+          </q-td>
+          <q-td>
+            <code class="text-caption">{{ props.row.fingerprint }}</code>
+          </q-td>
+          <q-td>
+            {{ props.row.comment }}
+          </q-td>
+          <q-td>
+            {{ formatDate(props.row.created_time) }}
+          </q-td>
+        </q-tr>
+      </template>
+    </q-table>
+  </div>
+</template>
+
+<script>
+import { ref, computed, onMounted } from "vue";
+import { useStore } from "vuex";
+import { fetchSSHKeys, removeSSHKey } from "@/api/accounts";
+import { useQuasar } from "quasar";
+import { notifySuccess } from "@/utils/notify";
+import SSHKeysForm from "@/components/core/SSHKeysForm.vue";
+
+const columns = [
+  {
+    name: "name",
+    label: "Name",
+    field: "name",
+    align: "left",
+    sortable: true,
+  },
+  {
+    name: "key_type",
+    label: "Type",
+    field: "key_type",
+    align: "left",
+    sortable: true,
+  },
+  {
+    name: "fingerprint",
+    label: "Fingerprint",
+    field: "fingerprint",
+    align: "left",
+    sortable: true,
+  },
+  {
+    name: "comment",
+    label: "Comment",
+    field: "comment",
+    align: "left",
+    sortable: true,
+  },
+  {
+    name: "created_time",
+    label: "Created",
+    field: "created_time",
+    align: "left",
+    sortable: true,
+  },
+  {
+    name: "actions",
+    label: "",
+    field: "actions",
+  },
+];
+
+export default {
+  name: "SSHKeysTable",
+  setup() {
+    const $q = useQuasar();
+    const store = useStore();
+    const formatDate = computed(() => store.getters.formatDate);
+
+    const keys = ref([]);
+    const loading = ref(false);
+
+    const pagination = ref({
+      rowsPerPage: 0,
+      sortBy: "name",
+      descending: true,
+    });
+
+    async function getSSHKeys() {
+      loading.value = true;
+      keys.value = await fetchSSHKeys();
+      loading.value = false;
+    }
+
+    async function deleteSSHKey(key) {
+      $q.dialog({
+        title: `Delete SSH key: ${key.name}?`,
+        cancel: true,
+        ok: { label: "Delete", color: "negative" },
+      }).onOk(async () => {
+        loading.value = true;
+        try {
+          const result = await removeSSHKey(key.id);
+          notifySuccess(result);
+          getSSHKeys();
+          loading.value = false;
+        } catch (e) {
+          console.error(e);
+          loading.value = false;
+        }
+      });
+    }
+
+    function editSSHKey(key) {
+      $q.dialog({
+        component: SSHKeysForm,
+        componentProps: {
+          SSHKey: key,
+        },
+      }).onOk(() => getSSHKeys());
+    }
+
+    function addSSHKey() {
+      $q.dialog({
+        component: SSHKeysForm,
+      }).onOk(() => getSSHKeys());
+    }
+
+    onMounted(getSSHKeys);
+
+    return {
+      keys,
+      loading,
+      pagination,
+      columns,
+      getSSHKeys,
+      deleteSSHKey,
+      formatDate,
+      editSSHKey,
+      addSSHKey,
+    };
+  },
+};
+</script>

--- a/src/components/modals/alerts/AlertTemplateForm.vue
+++ b/src/components/modals/alerts/AlertTemplateForm.vue
@@ -417,13 +417,13 @@
             </q-card-section>
             <q-card-section>
               <q-input
-                label="Alert again if not resolved after (days)"
+                label="Alert again if not resolved after (minutes)"
                 outlined
                 type="number"
-                v-model.number="template.agent_periodic_alert_days"
+                v-model.number="template.agent_periodic_alert_minutes"
                 dense
                 :rules="[
-                  (val) => val >= 0 || 'Periodic days must be 0 or greater',
+                  (val) => val >= 0 || 'Periodic minutes must be 0 or greater',
                 ]"
               />
             </q-card-section>
@@ -543,13 +543,13 @@
 
             <q-card-section>
               <q-input
-                label="Alert again if not resolved after (days)"
+                label="Alert again if not resolved after (minutes)"
                 outlined
                 type="number"
-                v-model.number="template.check_periodic_alert_days"
+                v-model.number="template.check_periodic_alert_minutes"
                 dense
                 :rules="[
-                  (val) => val >= 0 || 'Periodic days must be 0 or greater',
+                  (val) => val >= 0 || 'Periodic minutes must be 0 or greater',
                 ]"
               />
             </q-card-section>
@@ -669,13 +669,13 @@
 
             <q-card-section>
               <q-input
-                label="Alert again if not resolved (days)"
+                label="Alert again if not resolved (minutes)"
                 outlined
                 type="number"
-                v-model.number="template.task_periodic_alert_days"
+                v-model.number="template.task_periodic_alert_minutes"
                 dense
                 :rules="[
-                  (val) => val >= 0 || 'Periodic days must be 0 or greater',
+                  (val) => val >= 0 || 'Periodic minutes must be 0 or greater',
                 ]"
               />
             </q-card-section>
@@ -822,7 +822,7 @@ const template: AlertTemplate = props.alertTemplate
       agent_always_email: null,
       agent_always_text: null,
       agent_always_alert: null,
-      agent_periodic_alert_days: 0,
+      agent_periodic_alert_minutes: 0,
       agent_script_actions: true,
       check_email_alert_severity: [] as AlertSeverity[],
       check_text_alert_severity: [] as AlertSeverity[],
@@ -832,7 +832,7 @@ const template: AlertTemplate = props.alertTemplate
       check_always_email: null,
       check_always_text: null,
       check_always_alert: null,
-      check_periodic_alert_days: 0,
+      check_periodic_alert_minutes: 0,
       check_script_actions: true,
       task_email_alert_severity: [] as AlertSeverity[],
       task_text_alert_severity: [] as AlertSeverity[],
@@ -842,7 +842,7 @@ const template: AlertTemplate = props.alertTemplate
       task_always_email: null,
       task_always_text: null,
       task_always_alert: null,
-      task_periodic_alert_days: 0,
+      task_periodic_alert_minutes: 0,
       task_script_actions: true,
     });
 

--- a/src/components/modals/coresettings/EditCoreSettings.vue
+++ b/src/components/modals/coresettings/EditCoreSettings.vue
@@ -77,7 +77,28 @@
                   </q-checkbox>
                   <q-btn
                     size="sm"
-                    roundenable_server_webterminal
+                    round
+                    dense
+                    flat
+                    icon="warning"
+                    @click="
+                      openURL(
+                        'https://docs.tacticalrmm.com/functions/permissions/#permissions-with-extra-security-implications',
+                      )
+                    "
+                  >
+                  </q-btn>
+                </q-card-section>
+                <q-card-section v-if="!hosted" class="row">
+                  <q-checkbox
+                    v-model="settings.enable_ssh_gateway"
+                    label="Enable SSH gateway"
+                  >
+                    <q-tooltip>Enable SSH gateway for remote terminal access</q-tooltip>
+                  </q-checkbox>
+                  <q-btn
+                    size="sm"
+                    round
                     dense
                     flat
                     icon="warning"

--- a/src/components/modals/coresettings/EditCoreSettings.vue
+++ b/src/components/modals/coresettings/EditCoreSettings.vue
@@ -4,6 +4,7 @@
       <template v-slot:before>
         <q-tabs dense v-model="tab" vertical class="text-primary">
           <q-tab name="general" label="General" />
+          <q-tab name="sshgateway" label="SSH Gateway" />
           <q-tab name="emailalerts" label="Email Alerts" />
           <q-tab name="smsalerts" label="SMS Alerts" />
           <q-tab name="meshcentral" label="MeshCentral" />
@@ -74,27 +75,6 @@
                     label="Enable web terminal"
                   >
                     <q-tooltip>Enable the web terminal</q-tooltip>
-                  </q-checkbox>
-                  <q-btn
-                    size="sm"
-                    round
-                    dense
-                    flat
-                    icon="warning"
-                    @click="
-                      openURL(
-                        'https://docs.tacticalrmm.com/functions/permissions/#permissions-with-extra-security-implications',
-                      )
-                    "
-                  >
-                  </q-btn>
-                </q-card-section>
-                <q-card-section v-if="!hosted" class="row">
-                  <q-checkbox
-                    v-model="settings.enable_ssh_gateway"
-                    label="Enable SSH gateway"
-                  >
-                    <q-tooltip>Enable SSH gateway for remote terminal access</q-tooltip>
                   </q-checkbox>
                   <q-btn
                     size="sm"
@@ -332,6 +312,80 @@
                     color="negative"
                     label="Reset"
                     @click="showResetPatchPolicy"
+                  />
+                </q-card-section>
+              </q-tab-panel>
+              <!-- ssh gateway -->
+              <q-tab-panel name="sshgateway">
+                <div class="text-subtitle2">SSH Gateway Settings</div>
+                <q-separator />
+                <q-card-section v-if="!hosted" class="row">
+                  <q-checkbox
+                    v-model="settings.enable_ssh_gateway"
+                    label="Enable SSH gateway"
+                  >
+                    <q-tooltip>Enable SSH gateway for remote terminal access</q-tooltip>
+                  </q-checkbox>
+                  <q-btn
+                    size="sm"
+                    round
+                    dense
+                    flat
+                    icon="warning"
+                    @click="
+                      openURL(
+                        'https://docs.tacticalrmm.com/functions/permissions/#permissions-with-extra-security-implications',
+                      )
+                    "
+                  >
+                  </q-btn>
+                </q-card-section>
+                <q-card-section v-if="!hosted" class="row">
+                  <q-checkbox
+                    v-model="settings.ssh_gateway_enable_menu"
+                    label="Enable menu (SSH menu@host)"
+                  >
+                    <q-tooltip>Allow users to access the agent menu via SSH</q-tooltip>
+                  </q-checkbox>
+                </q-card-section>
+                <q-card-section v-if="!hosted" class="row">
+                  <q-checkbox
+                    v-model="settings.ssh_gateway_enable_exec"
+                    label="Enable exec (SSH host 'command')"
+                  >
+                    <q-tooltip>Allow users to run one-shot commands via SSH</q-tooltip>
+                  </q-checkbox>
+                </q-card-section>
+                <q-card-section v-if="!hosted" class="row">
+                  <q-checkbox
+                    v-model="settings.ssh_gateway_enable_terminal"
+                    label="Enable terminal (interactive shell)"
+                  >
+                    <q-tooltip>Allow users to open interactive shell sessions via SSH gateway</q-tooltip>
+                  </q-checkbox>
+                </q-card-section>
+                <q-card-section class="row">
+                  <div class="col-4">Session timeout (seconds):</div>
+                  <div class="col-2"></div>
+                  <q-input
+                    hint="Maximum time (in seconds) an SSH session can remain open"
+                    outlined
+                    dense
+                    v-model.number="settings.ssh_gateway_session_timeout"
+                    class="col-6"
+                    :rules="[(val) => val >= 0 || 'Minimum is 0']"
+                  />
+                </q-card-section>
+                <q-card-section class="row">
+                  <div class="col-4">Max concurrent sessions:</div>
+                  <div class="col-2"></div>
+                  <q-input
+                    hint="Maximum number of concurrent SSH sessions per user"
+                    outlined
+                    dense
+                    v-model.number="settings.ssh_gateway_max_sessions"
+                    class="col-6"
+                    :rules="[(val) => val >= 0 || 'Minimum is 0']"
                   />
                 </q-card-section>
               </q-tab-panel>
@@ -813,6 +867,7 @@
             <q-btn
               v-show="
                 tab === 'general' ||
+                tab === 'sshgateway' ||
                 tab === 'emailalerts' ||
                 tab === 'smsalerts' ||
                 tab === 'meshcentral' ||

--- a/src/components/modals/coresettings/EditCoreSettings.vue
+++ b/src/components/modals/coresettings/EditCoreSettings.vue
@@ -388,6 +388,18 @@
                     :rules="[(val) => val >= 0 || 'Minimum is 0']"
                   />
                 </q-card-section>
+                <q-card-section class="row">
+                  <div class="col-4">Max rate limit entries:</div>
+                  <div class="col-2"></div>
+                  <q-input
+                    hint="Maximum failed auth attempts before rate limiting kicks in"
+                    outlined
+                    dense
+                    v-model.number="settings.ssh_gateway_rate_limit_max_entries"
+                    class="col-6"
+                    :rules="[(val) => val >= 0 || 'Minimum is 0']"
+                  />
+                </q-card-section>
               </q-tab-panel>
               <!-- email alerts -->
               <q-tab-panel name="emailalerts">

--- a/src/components/modals/coresettings/UserPreferences.vue
+++ b/src/components/modals/coresettings/UserPreferences.vue
@@ -5,6 +5,7 @@
         <template v-slot:before>
           <q-tabs dense v-model="tab" vertical class="text-primary">
             <q-tab name="ui" label="User Interface" />
+            <q-tab name="sshkeys" label="SSH Keys" />
           </q-tabs>
         </template>
         <template v-slot:after>
@@ -217,6 +218,11 @@
                   />
                 </q-card-section>
               </q-tab-panel>
+
+              <!-- SSH Keys -->
+              <q-tab-panel name="sshkeys">
+                <SSHKeysTable />
+              </q-tab-panel>
             </q-tab-panels>
 
             <q-card-section class="row items-center">
@@ -233,10 +239,12 @@
 import { openURL } from "quasar";
 import { loadingBarColors } from "@/mixins/data";
 import mixins from "@/mixins/mixins";
+import SSHKeysTable from "@/components/core/SSHKeysTable.vue";
 
 export default {
   name: "UserPreferences",
   emits: ["hide", "ok", "cancel"],
+  components: { SSHKeysTable },
   mixins: [mixins],
   data() {
     return {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -43,6 +43,7 @@ export default function () {
         },
         server_scripts_enabled: true,
         web_terminal_enabled: true,
+        ssh_gateway_enabled: false,
         sso_enabled: false,
         block_local_user_logon: false,
       };
@@ -161,6 +162,9 @@ export default function () {
       setWebTerminalEnabled(state, obj) {
         state.web_terminal_enabled = obj;
       },
+      setSshGatewayEnabled(state, obj) {
+        state.ssh_gateway_enabled = obj;
+      },
       setSSOEnabled(state, obj) {
         state.sso_enabled = obj;
       },
@@ -253,6 +257,7 @@ export default function () {
         commit("setRunCmdPlaceholders", data.run_cmd_placeholder_text);
         commit("setServerScriptsEnabled", data.server_scripts_enabled);
         commit("setWebTerminalEnabled", data.web_terminal_enabled);
+        commit("setSshGatewayEnabled", data.ssh_gateway_enabled);
         commit("setBlockLocalUserLogon", data.block_local_user_logon);
 
         if (data?.date_format !== "") commit("setDateFormat", data.date_format);

--- a/src/types/alerts.ts
+++ b/src/types/alerts.ts
@@ -24,7 +24,7 @@ export interface AlertTemplate {
   agent_always_email: boolean | null;
   agent_always_text: boolean | null;
   agent_always_alert: boolean | null;
-  agent_periodic_alert_days: number;
+  agent_periodic_alert_minutes: number;
   agent_script_actions: boolean;
   check_email_alert_severity: AlertSeverity[];
   check_text_alert_severity: AlertSeverity[];
@@ -34,7 +34,7 @@ export interface AlertTemplate {
   check_always_email: boolean | null;
   check_always_text: boolean | null;
   check_always_alert: boolean | null;
-  check_periodic_alert_days: number;
+  check_periodic_alert_minutes: number;
   check_script_actions: boolean;
   task_email_alert_severity: AlertSeverity[];
   task_text_alert_severity: AlertSeverity[];
@@ -44,6 +44,6 @@ export interface AlertTemplate {
   task_always_email: boolean | null;
   task_always_text: boolean | null;
   task_always_alert: boolean | null;
-  task_periodic_alert_days: number;
+  task_periodic_alert_minutes: number;
   task_script_actions: boolean;
 }


### PR DESCRIPTION
Closes amidaware/tacticalrmm#1771
Requires amidaware/tacticalrmm#2488

Changes alert template re-alert interval from days to minutes to match the backend rename.

- Renames `agent_periodic_alert_days` → `agent_periodic_alert_minutes` in types
- Updates labels: "Alert again after (days)" → "(minutes)"
- Updates validation messages