### PR TITLE
Add Swagger API documentation toggle to CoreSettings UI

### DIFF
--- a/src/components/modals/coresettings/EditCoreSettings.vue
+++ b/src/components/modals/coresettings/EditCoreSettings.vue
@@ -731,6 +731,42 @@
               </q-tab-panel>
 
               <q-tab-panel name="apikeys">
+                <div class="text-subtitle2">Swagger API Documentation</div>
+                <q-separator />
+                <q-card-section class="row">
+                  <q-checkbox
+                    v-model="settings.enable_swagger"
+                    label="Enable Swagger API Explorer"
+                  >
+                    <q-tooltip
+                      >Enable a browser interface for browsing and testing the
+                      API</q-tooltip
+                    >
+                  </q-checkbox>
+                </q-card-section>
+                <q-card-section
+                  v-if="settings.enable_swagger"
+                  class="row items-center"
+                >
+                  <div class="col-4">Swagger UI URL:</div>
+                  <div class="col-2"></div>
+                  <q-input
+                    dense
+                    outlined
+                    readonly
+                    :model-value="swaggerUrl"
+                    class="col-4"
+                  />
+                  <q-btn
+                    flat
+                    dense
+                    icon="open_in_new"
+                    @click="openURL(swaggerUrl)"
+                    class="q-ml-sm"
+                  />
+                </q-card-section>
+                <div class="text-subtitle2 q-mt-lg">API Keys</div>
+                <q-separator />
                 <APIKeysTable />
               </q-tab-panel>
 
@@ -795,7 +831,8 @@
                 tab === 'emailalerts' ||
                 tab === 'smsalerts' ||
                 tab === 'meshcentral' ||
-                tab === 'retention'
+                tab === 'retention' ||
+                tab === 'apikeys'
               "
               label="Save"
               color="primary"
@@ -905,6 +942,13 @@ export default {
         { label: "Bash", value: "bash" },
         { label: "Custom", value: "custom" },
       ];
+    },
+    swaggerUrl() {
+      const base =
+        window._env_ && window._env_.PROD_URL
+          ? window._env_.PROD_URL
+          : "";
+      return `${base}/api/schema/swagger-ui/`;
     },
   },
   watch: {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -44,6 +44,7 @@ export default function () {
         server_scripts_enabled: true,
         web_terminal_enabled: true,
         sso_enabled: false,
+        swagger_enabled: false,
         block_local_user_logon: false,
       };
     },
@@ -164,6 +165,9 @@ export default function () {
       setSSOEnabled(state, obj) {
         state.sso_enabled = obj;
       },
+      setSwaggerEnabled(state, obj) {
+        state.swagger_enabled = obj;
+      },
       setBlockLocalUserLogon(state, obj) {
         state.block_local_user_logon = obj;
       },
@@ -253,6 +257,7 @@ export default function () {
         commit("setRunCmdPlaceholders", data.run_cmd_placeholder_text);
         commit("setServerScriptsEnabled", data.server_scripts_enabled);
         commit("setWebTerminalEnabled", data.web_terminal_enabled);
+        commit("setSwaggerEnabled", data.swagger_enabled);
         commit("setBlockLocalUserLogon", data.block_local_user_logon);
 
         if (data?.date_format !== "") commit("setDateFormat", data.date_format);


### PR DESCRIPTION
## Add Swagger API documentation toggle to CoreSettings UI

Adds UI controls in CoreSettings to enable Swagger API documentation and view its URL.

### Changes
- Add Swagger toggle checkbox in the API tab of EditCoreSettings modal
- Display Swagger UI URL with open action when enabled
- Add `swagger_enabled` to Vuex store state and mutations
- Handle `swagger_enabled` in `getDashInfo` action
- Add `apikeys` tab to save button visibility conditions

### Backend PR
**Backend:** https://github.com/amidaware/tacticalrmm/pull/2493