### PR TITLE
Add customizable email template UI

### DIFF
--- a/src/components/modals/coresettings/EditCoreSettings.vue
+++ b/src/components/modals/coresettings/EditCoreSettings.vue
@@ -453,6 +453,145 @@
                     </template>
                   </q-input>
                 </q-card-section>
+                <div class="text-subtitle2">Checks</div>
+                <q-separator />
+                <q-card-section class="row">
+                  <div class="col-2">Subject template:</div>
+                  <div class="col-4 text-caption text-grey-7 q-pr-lg">
+                    Available: <b>{agent}</b>, <b>{client}</b>,
+                    <b>{site}</b>, <b>{site_id}</b>, <b>{policy}</b>, <b>{alert_name}</b>,
+                    <b>{check_name}</b>, <b>{check_description}</b>,
+                    <b>{alert_status}</b>, <b>{subject}</b>.
+                  </div>
+                  <q-input
+                    outlined
+                    dense
+                    v-model="settings.check_email_subject_template"
+                    class="col-6 q-pa-none"
+                    placeholder="Leave blank to use the built-in check subject"
+                  />
+                </q-card-section>
+                <q-card-section class="row">
+                  <div class="col-2">Body template:</div>
+                  <div class="col-4 text-caption text-grey-7 q-pr-lg">
+                    Available: <b>{details}</b>, <b>{more_info}</b>, <b>{stdout}</b>,
+                    <b>{stderr}</b>, <b>{retcode}</b>, <b>{body}</b>,
+                    <b>{subject}</b>, <b>{agent}</b>, <b>{client}</b>,
+                    <b>{site}</b>, <b>{site_id}</b>, <b>{policy}</b>, <b>{check_name}</b>.
+                  </div>
+                  <q-input
+                    outlined
+                    dense
+                    autogrow
+                    type="textarea"
+                    v-model="settings.check_email_body_template"
+                    class="col-6 q-pa-none"
+                    placeholder="Leave blank to use the built-in check body"
+                  />
+                </q-card-section>
+                <div class="text-subtitle2">Tasks</div>
+                <q-separator />
+                <q-card-section class="row">
+                  <div class="col-2">Subject template:</div>
+                  <div class="col-4 text-caption text-grey-7 q-pr-lg">
+                    Available: <b>{agent}</b>, <b>{client}</b>,
+                    <b>{site}</b>, <b>{site_id}</b>, <b>{policy}</b>, <b>{alert_name}</b>,
+                    <b>{task_name}</b>, <b>{alert_status}</b>, <b>{subject}</b>.
+                  </div>
+                  <q-input
+                    outlined
+                    dense
+                    v-model="settings.task_email_subject_template"
+                    class="col-6 q-pa-none"
+                    placeholder="Leave blank to use the built-in task subject"
+                  />
+                </q-card-section>
+                <q-card-section class="row">
+                  <div class="col-2">Body template:</div>
+                  <div class="col-4 text-caption text-grey-7 q-pr-lg">
+                    Available: <b>{details}</b>, <b>{stdout}</b>, <b>{stderr}</b>,
+                    <b>{retcode}</b>, <b>{body}</b>, <b>{subject}</b>,
+                    <b>{agent}</b>, <b>{client}</b>, <b>{site}</b>, <b>{site_id}</b>,
+                    <b>{policy}</b>, <b>{task_name}</b>.
+                  </div>
+                  <q-input
+                    outlined
+                    dense
+                    autogrow
+                    type="textarea"
+                    v-model="settings.task_email_body_template"
+                    class="col-6 q-pa-none"
+                    placeholder="Leave blank to use the built-in task body"
+                  />
+                </q-card-section>
+                <div class="text-subtitle2">Agent Offline</div>
+                <q-separator />
+                <q-card-section class="row">
+                  <div class="col-2">Subject template:</div>
+                  <div class="col-4 text-caption text-grey-7 q-pr-lg">
+                    Available: <b>{agent}</b>, <b>{client}</b>,
+                    <b>{site}</b>, <b>{site_id}</b>, <b>{policy}</b>, <b>{alert_name}</b>,
+                    <b>{alert_status}</b>, <b>{subject}</b>.
+                  </div>
+                  <q-input
+                    outlined
+                    dense
+                    v-model="settings.agent_outage_email_subject_template"
+                    class="col-6 q-pa-none"
+                    placeholder="Leave blank to use the built-in offline subject"
+                  />
+                </q-card-section>
+                <q-card-section class="row">
+                  <div class="col-2">Body template:</div>
+                  <div class="col-4 text-caption text-grey-7 q-pr-lg">
+                    Available: <b>{details}</b>, <b>{body}</b>, <b>{subject}</b>,
+                    <b>{agent}</b>, <b>{client}</b>, <b>{site}</b>,
+                    <b>{site_id}</b>, <b>{policy}</b>.
+                  </div>
+                  <q-input
+                    outlined
+                    dense
+                    autogrow
+                    type="textarea"
+                    v-model="settings.agent_outage_email_body_template"
+                    class="col-6 q-pa-none"
+                    placeholder="Leave blank to use the built-in offline body"
+                  />
+                </q-card-section>
+                <div class="text-subtitle2">Agent Recovered</div>
+                <q-separator />
+                <q-card-section class="row">
+                  <div class="col-2">Subject template:</div>
+                  <div class="col-4 text-caption text-grey-7 q-pr-lg">
+                    Available: <b>{agent}</b>, <b>{client}</b>,
+                    <b>{site}</b>, <b>{site_id}</b>, <b>{policy}</b>, <b>{alert_name}</b>,
+                    <b>{alert_status}</b>, <b>{subject}</b>.
+                  </div>
+                  <q-input
+                    outlined
+                    dense
+                    v-model="settings.agent_recovery_email_subject_template"
+                    class="col-6 q-pa-none"
+                    placeholder="Leave blank to use the built-in recovery subject"
+                  />
+                </q-card-section>
+                <q-card-section class="row">
+                  <div class="col-2">Body template:</div>
+                  <div class="col-4 text-caption text-grey-7 q-pr-lg">
+                    Available: <b>{details}</b>, <b>{body}</b>, <b>{subject}</b>,
+                    <b>{agent}</b>, <b>{client}</b>, <b>{site}</b>,
+                    <b>{site_id}</b>, <b>{policy}</b>.
+                  </div>
+                  <q-input
+                    outlined
+                    dense
+                    autogrow
+                    type="textarea"
+                    v-model="settings.agent_recovery_email_body_template"
+                    class="col-6 q-pa-none"
+                    placeholder="Leave blank to use the built-in recovery body"
+                  />
+                </q-card-section>
               </q-tab-panel>
               <!-- twilio sms alerts -->
               <q-tab-panel name="smsalerts">

--- a/src/components/modals/coresettings/EditCoreSettings.vue
+++ b/src/components/modals/coresettings/EditCoreSettings.vue
@@ -531,7 +531,7 @@
                   <div class="col-4 text-caption text-grey-7 q-pr-lg">
                     Available: <b>{agent}</b>, <b>{client}</b>,
                     <b>{site}</b>, <b>{site_id}</b>, <b>{policy}</b>, <b>{alert_name}</b>,
-                    <b>{alert_status}</b>, <b>{subject}</b>.
+                    <b>{alert_status}</b>, <b>{last_response}</b>, <b>{subject}</b>.
                   </div>
                   <q-input
                     outlined
@@ -546,7 +546,7 @@
                   <div class="col-4 text-caption text-grey-7 q-pr-lg">
                     Available: <b>{details}</b>, <b>{body}</b>, <b>{subject}</b>,
                     <b>{agent}</b>, <b>{client}</b>, <b>{site}</b>,
-                    <b>{site_id}</b>, <b>{policy}</b>.
+                    <b>{site_id}</b>, <b>{policy}</b>, <b>{last_response}</b>.
                   </div>
                   <q-input
                     outlined
@@ -565,7 +565,7 @@
                   <div class="col-4 text-caption text-grey-7 q-pr-lg">
                     Available: <b>{agent}</b>, <b>{client}</b>,
                     <b>{site}</b>, <b>{site_id}</b>, <b>{policy}</b>, <b>{alert_name}</b>,
-                    <b>{alert_status}</b>, <b>{subject}</b>.
+                    <b>{alert_status}</b>, <b>{last_response}</b>, <b>{subject}</b>.
                   </div>
                   <q-input
                     outlined
@@ -580,7 +580,7 @@
                   <div class="col-4 text-caption text-grey-7 q-pr-lg">
                     Available: <b>{details}</b>, <b>{body}</b>, <b>{subject}</b>,
                     <b>{agent}</b>, <b>{client}</b>, <b>{site}</b>,
-                    <b>{site_id}</b>, <b>{policy}</b>.
+                    <b>{site_id}</b>, <b>{policy}</b>, <b>{last_response}</b>.
                   </div>
                   <q-input
                     outlined

--- a/src/types/core/settings.ts
+++ b/src/types/core/settings.ts
@@ -3,4 +3,14 @@ export interface CoreSetting {
   all_timezones: string[];
   default_time_zone: string;
   email_alert_recipients: string[];
+  email_subject_template: string;
+  email_body_template: string;
+  check_email_subject_template: string;
+  check_email_body_template: string;
+  task_email_subject_template: string;
+  task_email_body_template: string;
+  agent_outage_email_subject_template: string;
+  agent_outage_email_body_template: string;
+  agent_recovery_email_subject_template: string;
+  agent_recovery_email_body_template: string;
 }


### PR DESCRIPTION
## Summary

Adds UI support for customizable email subject and body templates in Global Settings.

## Changes

- adds editable email template fields in the settings UI
- supports separate template inputs for:
  - checks
  - tasks
  - agent offline
  - agent recovered
- placeholders to explain that leaving a field empty keeps the built-in subject/body
- adjusts spacing in the helper text layout for better readability

## Notes

https://github.com/user-attachments/assets/e8588d82-878c-442b-9aa2-4c6bc912f79f

## Related

Backend PR:
- https://github.com/amidaware/tacticalrmm/pull/2503

Docs PR:
- https://github.com/amidaware/trmm-docs/pull/340