### PR TITLE
Add passkey authentication UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "serve": "quasar dev",
     "build": "quasar build",
+    "test": "node --test tests/*.test.mjs",
     "lint": "eslint --ext .js,.ts,.vue ./",
     "format": "prettier --write \"**/*.{js,ts,vue,,html,md,json}\" --ignore-path .gitignore"
   },

--- a/src/api/webauthn.ts
+++ b/src/api/webauthn.ts
@@ -1,0 +1,230 @@
+import axios from "axios";
+
+const baseUrl = "/accounts";
+
+export type PasskeyAttachment = "platform" | "cross-platform";
+
+export interface Passkey {
+  id: number;
+  nickname: string | null;
+  transports: string[];
+  created_at: string;
+  last_used_at: string | null;
+  device_id: string | null;
+}
+
+type CredentialJSON = Record<string, unknown>;
+
+function base64urlToArrayBuffer(value: string): ArrayBuffer {
+  const padded = value
+    .replace(/-/g, "+")
+    .replace(/_/g, "/")
+    .padEnd(Math.ceil(value.length / 4) * 4, "=");
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+
+  return bytes.buffer;
+}
+
+function arrayBufferToBase64url(value: ArrayBuffer): string {
+  const bytes = new Uint8Array(value);
+  let binary = "";
+
+  for (let i = 0; i < bytes.byteLength; i += 1) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+function decodeRequestOptions(
+  options: PublicKeyCredentialRequestOptions & {
+    challenge: string;
+    allowCredentials?: Array<PublicKeyCredentialDescriptor & { id: string }>;
+  },
+): PublicKeyCredentialRequestOptions {
+  return {
+    ...options,
+    challenge: base64urlToArrayBuffer(options.challenge),
+    allowCredentials: options.allowCredentials?.map((credential) => ({
+      ...credential,
+      id: base64urlToArrayBuffer(credential.id),
+    })),
+  };
+}
+
+function decodeCreationOptions(
+  options: PublicKeyCredentialCreationOptions & {
+    challenge: string;
+    user: PublicKeyCredentialUserEntity & { id: string };
+    excludeCredentials?: Array<PublicKeyCredentialDescriptor & { id: string }>;
+  },
+): PublicKeyCredentialCreationOptions {
+  return {
+    ...options,
+    challenge: base64urlToArrayBuffer(options.challenge),
+    user: {
+      ...options.user,
+      id: base64urlToArrayBuffer(options.user.id),
+    },
+    excludeCredentials: options.excludeCredentials?.map((credential) => ({
+      ...credential,
+      id: base64urlToArrayBuffer(credential.id),
+    })),
+  };
+}
+
+export function credentialToJSON(
+  credential: PublicKeyCredential,
+): CredentialJSON {
+  const response = credential.response;
+  const body: CredentialJSON = {
+    id: credential.id,
+    rawId: arrayBufferToBase64url(credential.rawId),
+    type: credential.type,
+    clientExtensionResults: credential.getClientExtensionResults(),
+  };
+
+  if (credential.authenticatorAttachment) {
+    body.authenticatorAttachment = credential.authenticatorAttachment;
+  }
+
+  if (response instanceof AuthenticatorAttestationResponse) {
+    body.response = {
+      attestationObject: arrayBufferToBase64url(response.attestationObject),
+      clientDataJSON: arrayBufferToBase64url(response.clientDataJSON),
+    };
+  } else if (response instanceof AuthenticatorAssertionResponse) {
+    body.response = {
+      authenticatorData: arrayBufferToBase64url(response.authenticatorData),
+      clientDataJSON: arrayBufferToBase64url(response.clientDataJSON),
+      signature: arrayBufferToBase64url(response.signature),
+      userHandle: response.userHandle
+        ? arrayBufferToBase64url(response.userHandle)
+        : null,
+    };
+  }
+
+  return body;
+}
+
+export function credentialTransports(
+  credential: PublicKeyCredential,
+): string[] {
+  const response = credential.response;
+
+  if (
+    response instanceof AuthenticatorAttestationResponse &&
+    typeof response.getTransports === "function"
+  ) {
+    return response.getTransports();
+  }
+
+  return [];
+}
+
+export function isWebAuthnSupported() {
+  return !!window.PublicKeyCredential && !!navigator.credentials;
+}
+
+function assertWebAuthnSupported() {
+  if (!isWebAuthnSupported()) {
+    throw new Error("Passkeys are not supported by this browser.");
+  }
+}
+
+export async function beginPasskeyLogin() {
+  const { data } = await axios.post(`${baseUrl}/webauthn/login/begin/`);
+  return data;
+}
+
+export async function getPasskeyAssertion(
+  options: PublicKeyCredentialRequestOptions & { challenge: string },
+): Promise<PublicKeyCredential> {
+  assertWebAuthnSupported();
+  const credential = await navigator.credentials.get({
+    publicKey: decodeRequestOptions(options),
+  });
+
+  if (!(credential instanceof PublicKeyCredential)) {
+    throw new Error("Passkey verification was cancelled.");
+  }
+
+  return credential;
+}
+
+export async function completePasskeyLogin(credential: CredentialJSON) {
+  const { data } = await axios.post(`${baseUrl}/webauthn/login/complete/`, {
+    credential,
+  });
+  return data;
+}
+
+export async function fetchPasskeys(): Promise<Passkey[]> {
+  const { data } = await axios.get(`${baseUrl}/passkeys/`);
+  return data;
+}
+
+export async function beginPasskeyRegistration(attachment?: PasskeyAttachment) {
+  const { data } = await axios.post(`${baseUrl}/webauthn/register/begin/`, {
+    attachment,
+  });
+  return data;
+}
+
+export async function createPasskeyCredential(
+  options: PublicKeyCredentialCreationOptions & { challenge: string },
+): Promise<PublicKeyCredential> {
+  assertWebAuthnSupported();
+  const credential = await navigator.credentials.create({
+    publicKey: decodeCreationOptions(options),
+  });
+
+  if (!(credential instanceof PublicKeyCredential)) {
+    throw new Error("Passkey registration was cancelled.");
+  }
+
+  return credential;
+}
+
+export async function completePasskeyRegistration(
+  credential: CredentialJSON,
+  nickname: string | null,
+  transports: string[],
+) {
+  const { data } = await axios.post(`${baseUrl}/webauthn/register/complete/`, {
+    credential,
+    nickname,
+    transports,
+  });
+  return data;
+}
+
+export async function renamePasskey(id: number, nickname: string | null) {
+  const { data } = await axios.post(`${baseUrl}/passkeys/${id}/rename/`, {
+    nickname,
+  });
+  return data;
+}
+
+export async function deletePasskey(id: number) {
+  const { data } = await axios.post(`${baseUrl}/passkeys/${id}/delete/`);
+  return data;
+}
+
+export async function fetchUserPasskeys(userId: number): Promise<Passkey[]> {
+  const { data } = await axios.get(`${baseUrl}/users/${userId}/passkeys/`);
+  return data;
+}
+
+export async function resetUserPasskeys(userId: number) {
+  const { data } = await axios.delete(`${baseUrl}/users/${userId}/passkeys/`);
+  return data;
+}

--- a/src/components/AdminManager.vue
+++ b/src/components/AdminManager.vue
@@ -109,14 +109,49 @@
                 <q-item
                   clickable
                   v-close-popup
-                  @click="reset2FA(props.row)"
+                  @click="resetMFA(props.row)"
                   id="context-reset"
                   :disable="props.row.social_accounts.length !== 0"
                 >
                   <q-item-section side>
                     <q-icon name="autorenew" />
                   </q-item-section>
-                  <q-item-section>Reset Two-Factor Auth</q-item-section>
+                  <q-item-section>Reset MFA</q-item-section>
+                </q-item>
+
+                <q-item
+                  clickable
+                  v-close-popup
+                  @click="showPasskeys(props.row)"
+                >
+                  <q-item-section side>
+                    <q-icon name="vpn_key" />
+                  </q-item-section>
+                  <q-item-section>Show Passkeys</q-item-section>
+                </q-item>
+
+                <q-item
+                  v-if="props.row.username === logged_in_user"
+                  clickable
+                  v-close-popup
+                  @click="showMyPasskeyPreferences"
+                >
+                  <q-item-section side>
+                    <q-icon name="add" />
+                  </q-item-section>
+                  <q-item-section>Add My Passkey</q-item-section>
+                </q-item>
+
+                <q-item
+                  clickable
+                  v-close-popup
+                  @click="resetPasskeys(props.row)"
+                  :disable="props.row.passkey_count === 0"
+                >
+                  <q-item-section side>
+                    <q-icon name="delete" />
+                  </q-item-section>
+                  <q-item-section>Reset Passkeys</q-item-section>
                 </q-item>
 
                 <q-separator></q-separator>
@@ -173,6 +208,26 @@
             <q-td>{{ props.row.username }}</q-td>
             <q-td>{{ props.row.first_name }} {{ props.row.last_name }}</q-td>
             <q-td>{{ props.row.email }}</q-td>
+            <q-td>
+              <q-chip
+                v-if="props.row.totp_enabled"
+                dense
+                square
+                class="mfa-chip"
+                color="secondary"
+                text-color="white"
+                >TOTP</q-chip
+              >
+              <q-chip
+                dense
+                square
+                class="mfa-chip"
+                :color="props.row.passkey_count > 0 ? 'positive' : 'grey-7'"
+                text-color="white"
+                icon-right="vpn_key"
+                >{{ props.row.passkey_count }}</q-chip
+              >
+            </q-td>
             <q-td v-if="props.row.last_login">{{
               formatDate(props.row.last_login)
             }}</q-td>
@@ -197,6 +252,9 @@ import UserForm from "@/components/modals/admin/UserForm.vue";
 import UserResetPasswordForm from "@/components/modals/admin/UserResetPasswordForm.vue";
 import SSOAccountsTable from "@/ee/sso/components/SSOAccountsTable.vue";
 import UserSessionsTable from "@/components/accounts/UserSessionsTable.vue";
+import UserPasskeysTable from "@/components/accounts/UserPasskeysTable.vue";
+import UserPreferences from "@/components/modals/coresettings/UserPreferences.vue";
+import { resetUserPasskeys } from "@/api/webauthn";
 
 export default {
   name: "AdminManager",
@@ -267,6 +325,13 @@ export default {
           name: "email",
           label: "Email",
           field: "email",
+          align: "left",
+          sortable: true,
+        },
+        {
+          name: "mfa",
+          label: "MFA",
+          field: "passkey_count",
           align: "left",
           sortable: true,
         },
@@ -369,14 +434,48 @@ export default {
           this.getUsers();
         });
     },
-    reset2FA(user) {
+    showPasskeys(user) {
+      this.$q
+        .dialog({
+          component: UserPasskeysTable,
+          componentProps: {
+            user: user,
+          },
+        })
+        .onOk(() => {
+          this.getUsers();
+        });
+    },
+    showMyPasskeyPreferences() {
+      this.$q.dialog({
+        component: UserPreferences,
+        componentProps: {
+          initialTab: "security",
+        },
+      });
+    },
+    resetPasskeys(user) {
+      this.$q
+        .dialog({
+          title: `Reset passkeys for ${user.username}?`,
+          cancel: true,
+          ok: { label: "Reset", color: "negative" },
+        })
+        .onOk(async () => {
+          const response = await resetUserPasskeys(user.id);
+          this.notifySuccess(`Removed ${response.deleted} passkey(s)`, 4000);
+          this.getUsers();
+        });
+    },
+    resetMFA(user) {
       const data = {
         id: user.id,
       };
 
       this.$q
         .dialog({
-          title: `Reset 2FA for ${user.username}?`,
+          title: `Reset MFA for ${user.username}?`,
+          message: "This removes the TOTP secret and all enrolled passkeys.",
           cancel: true,
           ok: { label: "Reset", color: "positive" },
         })
@@ -399,3 +498,9 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+.mfa-chip {
+  border-radius: 6px;
+}
+</style>

--- a/src/components/accounts/PasskeyManager.vue
+++ b/src/components/accounts/PasskeyManager.vue
@@ -1,0 +1,329 @@
+<template>
+  <div>
+    <div class="row items-center q-gutter-sm q-mb-sm">
+      <q-btn-dropdown
+        dense
+        color="secondary"
+        dropdown-icon="more_horiz"
+        label="Other"
+        no-caps
+        class="passkey-action-btn"
+      >
+        <q-list dense style="min-width: 180px">
+          <q-item
+            clickable
+            v-close-popup
+            @click="addPasskey(enrollmentOptions.browser)"
+          >
+            <q-item-section>Browser Choice</q-item-section>
+            <q-item-section side>
+              <q-icon name="devices" />
+            </q-item-section>
+          </q-item>
+          <q-item
+            clickable
+            v-close-popup
+            @click="addPasskey(enrollmentOptions.securityKey)"
+          >
+            <q-item-section>Security Key</q-item-section>
+            <q-item-section side>
+              <q-icon name="vpn_key" />
+            </q-item-section>
+          </q-item>
+        </q-list>
+      </q-btn-dropdown>
+      <q-btn
+        dense
+        color="secondary"
+        icon-right="phone_iphone"
+        label="Phone"
+        no-caps
+        class="passkey-action-btn"
+        @click="addPasskey(enrollmentOptions.phone)"
+      />
+      <q-btn
+        dense
+        color="primary"
+        icon-right="fingerprint"
+        label="This Device"
+        no-caps
+        class="passkey-action-btn"
+        @click="addPasskey(enrollmentOptions.thisDevice)"
+      />
+      <q-space />
+      <q-btn
+        dense
+        flat
+        class="passkey-icon-btn"
+        icon="refresh"
+        @click="loadPasskeys"
+      >
+        <q-tooltip>Refresh passkeys</q-tooltip>
+      </q-btn>
+    </div>
+
+    <q-table
+      dense
+      flat
+      bordered
+      row-key="id"
+      :rows="passkeys"
+      :columns="columns"
+      :pagination="{ rowsPerPage: 0 }"
+      hide-pagination
+      no-data-label="No passkeys enrolled"
+    >
+      <template v-slot:body-cell-nickname="props">
+        <q-td :props="props">
+          {{ props.row.nickname || "Unnamed passkey" }}
+        </q-td>
+      </template>
+
+      <template v-slot:body-cell-transports="props">
+        <q-td :props="props">
+          <q-chip
+            v-for="transport in props.row.transports"
+            :key="transport"
+            dense
+            square
+            class="passkey-chip"
+            color="primary"
+            text-color="white"
+          >
+            {{ transport }}
+          </q-chip>
+          <span v-if="props.row.transports.length === 0">Browser</span>
+        </q-td>
+      </template>
+
+      <template v-slot:body-cell-created_at="props">
+        <q-td :props="props">{{ formatDateTime(props.row.created_at) }}</q-td>
+      </template>
+
+      <template v-slot:body-cell-last_used_at="props">
+        <q-td :props="props">{{ formatDateTime(props.row.last_used_at) }}</q-td>
+      </template>
+
+      <template v-slot:body-cell-actions="props">
+        <q-td :props="props" auto-width>
+          <q-btn
+            dense
+            flat
+            class="passkey-icon-btn"
+            icon="edit"
+            @click="renameExistingPasskey(props.row)"
+          >
+            <q-tooltip>Rename passkey</q-tooltip>
+          </q-btn>
+          <q-btn
+            dense
+            flat
+            class="passkey-icon-btn"
+            color="negative"
+            icon="delete"
+            @click="removePasskey(props.row)"
+          >
+            <q-tooltip>Delete passkey</q-tooltip>
+          </q-btn>
+        </q-td>
+      </template>
+    </q-table>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from "vue";
+import { date, useQuasar, type QTableColumn } from "quasar";
+import {
+  beginPasskeyRegistration,
+  completePasskeyRegistration,
+  createPasskeyCredential,
+  credentialToJSON,
+  credentialTransports,
+  deletePasskey,
+  fetchPasskeys,
+  renamePasskey,
+  type Passkey,
+  type PasskeyAttachment,
+} from "@/api/webauthn";
+import { notifyError, notifySuccess } from "@/utils/notify";
+
+const emit = defineEmits(["changed"]);
+const $q = useQuasar();
+const passkeys = ref<Passkey[]>([]);
+
+interface EnrollmentOption {
+  attachment?: PasskeyAttachment;
+  dialogTitle: string;
+  defaultName: string;
+}
+
+const enrollmentOptions: Record<
+  "browser" | "securityKey" | "phone" | "thisDevice",
+  EnrollmentOption
+> = {
+  browser: {
+    dialogTitle: "Add passkey",
+    defaultName: "Passkey",
+  },
+  securityKey: {
+    attachment: "cross-platform",
+    dialogTitle: "Add security key",
+    defaultName: "Security key",
+  },
+  phone: {
+    attachment: "cross-platform",
+    dialogTitle: "Add phone passkey",
+    defaultName: "Phone passkey",
+  },
+  thisDevice: {
+    attachment: "platform",
+    dialogTitle: "Add this device",
+    defaultName: "This device",
+  },
+};
+
+const columns: QTableColumn[] = [
+  {
+    name: "nickname",
+    label: "Name",
+    field: "nickname",
+    align: "left",
+    sortable: true,
+  },
+  {
+    name: "transports",
+    label: "Type",
+    field: "transports",
+    align: "left",
+  },
+  {
+    name: "created_at",
+    label: "Created",
+    field: "created_at",
+    align: "left",
+    sortable: true,
+  },
+  {
+    name: "last_used_at",
+    label: "Last Used",
+    field: "last_used_at",
+    align: "left",
+    sortable: true,
+  },
+  {
+    name: "device_id",
+    label: "Device ID",
+    field: "device_id",
+    align: "left",
+  },
+  {
+    name: "actions",
+    label: "",
+    field: "actions",
+    align: "right",
+  },
+];
+
+function formatDateTime(value: string | null) {
+  return value ? date.formatDate(value, "YYYY-MM-DD HH:mm") : "Never";
+}
+
+async function loadPasskeys() {
+  passkeys.value = await fetchPasskeys();
+}
+
+function promptPasskeyName(option: EnrollmentOption) {
+  return new Promise<string | null>((resolve) => {
+    $q.dialog({
+      title: option.dialogTitle,
+      prompt: {
+        model: option.defaultName,
+        type: "text",
+        label: "Passkey name",
+      },
+      cancel: true,
+      ok: { label: "Continue" },
+      persistent: true,
+    })
+      .onOk((nickname: string) =>
+        resolve(nickname.trim() || option.defaultName),
+      )
+      .onCancel(() => resolve(null));
+  });
+}
+
+async function addPasskey(option: EnrollmentOption) {
+  const nickname = await promptPasskeyName(option);
+  if (nickname === null) return;
+
+  $q.loading.show();
+  try {
+    const options = await beginPasskeyRegistration(option.attachment);
+    const credential = await createPasskeyCredential(options);
+    await completePasskeyRegistration(
+      credentialToJSON(credential),
+      nickname,
+      credentialTransports(credential),
+    );
+    notifySuccess("Passkey added");
+    await loadPasskeys();
+    emit("changed");
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Passkey registration failed";
+    notifyError(message, 3500);
+  } finally {
+    $q.loading.hide();
+  }
+}
+
+function renameExistingPasskey(passkey: Passkey) {
+  $q.dialog({
+    title: "Rename passkey",
+    prompt: {
+      model: passkey.nickname || "",
+      type: "text",
+      label: "Name",
+    },
+    cancel: true,
+    persistent: true,
+  }).onOk(async (nickname: string) => {
+    await renamePasskey(passkey.id, nickname || null);
+    notifySuccess("Passkey renamed");
+    await loadPasskeys();
+    emit("changed");
+  });
+}
+
+function removePasskey(passkey: Passkey) {
+  $q.dialog({
+    title: `Delete ${passkey.nickname || "passkey"}?`,
+    cancel: true,
+    ok: { label: "Delete", color: "negative" },
+  }).onOk(async () => {
+    await deletePasskey(passkey.id);
+    notifySuccess("Passkey deleted");
+    await loadPasskeys();
+    emit("changed");
+  });
+}
+
+onMounted(loadPasskeys);
+</script>
+
+<style scoped>
+.passkey-action-btn,
+.passkey-icon-btn {
+  border-radius: 6px;
+}
+
+.passkey-icon-btn {
+  min-height: 30px;
+  min-width: 30px;
+}
+
+.passkey-chip {
+  border-radius: 6px;
+}
+</style>

--- a/src/components/accounts/UserPasskeysTable.vue
+++ b/src/components/accounts/UserPasskeysTable.vue
@@ -1,0 +1,183 @@
+<template>
+  <q-dialog ref="dialogRef" @hide="onDialogHide">
+    <q-card style="min-width: 60vw">
+      <q-card-section class="row items-center">
+        <div class="text-h6">Passkeys for {{ user.username }}</div>
+        <q-space />
+        <q-btn dense flat class="passkey-icon-btn" icon="close" v-close-popup />
+      </q-card-section>
+
+      <q-card-section>
+        <div class="row items-center q-gutter-sm q-mb-sm">
+          <q-btn
+            dense
+            flat
+            class="passkey-icon-btn"
+            icon="refresh"
+            @click="loadPasskeys"
+          >
+            <q-tooltip>Refresh passkeys</q-tooltip>
+          </q-btn>
+          <q-space />
+          <q-btn
+            dense
+            color="negative"
+            icon="delete"
+            label="Reset Passkeys"
+            no-caps
+            :disable="passkeys.length === 0"
+            @click="resetPasskeys"
+          />
+        </div>
+
+        <q-table
+          dense
+          flat
+          bordered
+          row-key="id"
+          :rows="passkeys"
+          :columns="columns"
+          :pagination="{ rowsPerPage: 0 }"
+          hide-pagination
+          no-data-label="No passkeys enrolled"
+        >
+          <template v-slot:body-cell-nickname="props">
+            <q-td :props="props">
+              {{ props.row.nickname || "Unnamed passkey" }}
+            </q-td>
+          </template>
+
+          <template v-slot:body-cell-transports="props">
+            <q-td :props="props">
+              <q-chip
+                v-for="transport in props.row.transports"
+                :key="transport"
+                dense
+                square
+                class="passkey-chip"
+                color="primary"
+                text-color="white"
+              >
+                {{ transport }}
+              </q-chip>
+              <span v-if="props.row.transports.length === 0">Browser</span>
+            </q-td>
+          </template>
+
+          <template v-slot:body-cell-created_at="props">
+            <q-td :props="props">{{
+              formatDateTime(props.row.created_at)
+            }}</q-td>
+          </template>
+
+          <template v-slot:body-cell-last_used_at="props">
+            <q-td :props="props">{{
+              formatDateTime(props.row.last_used_at)
+            }}</q-td>
+          </template>
+        </q-table>
+      </q-card-section>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from "vue";
+import {
+  date,
+  useDialogPluginComponent,
+  useQuasar,
+  type QTableColumn,
+} from "quasar";
+import {
+  fetchUserPasskeys,
+  resetUserPasskeys,
+  type Passkey,
+} from "@/api/webauthn";
+import { notifySuccess } from "@/utils/notify";
+
+interface AdminUser {
+  id: number;
+  username: string;
+}
+
+const props = defineProps<{
+  user: AdminUser;
+}>();
+
+defineEmits([...useDialogPluginComponent.emits]);
+
+const { dialogRef, onDialogHide } = useDialogPluginComponent();
+const $q = useQuasar();
+const passkeys = ref<Passkey[]>([]);
+
+const columns: QTableColumn[] = [
+  {
+    name: "nickname",
+    label: "Name",
+    field: "nickname",
+    align: "left",
+    sortable: true,
+  },
+  {
+    name: "transports",
+    label: "Type",
+    field: "transports",
+    align: "left",
+  },
+  {
+    name: "created_at",
+    label: "Created",
+    field: "created_at",
+    align: "left",
+    sortable: true,
+  },
+  {
+    name: "last_used_at",
+    label: "Last Used",
+    field: "last_used_at",
+    align: "left",
+    sortable: true,
+  },
+  {
+    name: "device_id",
+    label: "Device ID",
+    field: "device_id",
+    align: "left",
+  },
+];
+
+function formatDateTime(value: string | null) {
+  return value ? date.formatDate(value, "YYYY-MM-DD HH:mm") : "Never";
+}
+
+async function loadPasskeys() {
+  passkeys.value = await fetchUserPasskeys(props.user.id);
+}
+
+function resetPasskeys() {
+  $q.dialog({
+    title: `Reset passkeys for ${props.user.username}?`,
+    cancel: true,
+    ok: { label: "Reset", color: "negative" },
+  }).onOk(async () => {
+    const result = await resetUserPasskeys(props.user.id);
+    notifySuccess(`Removed ${result.deleted} passkey(s)`);
+    await loadPasskeys();
+  });
+}
+
+onMounted(loadPasskeys);
+</script>
+
+<style scoped>
+.passkey-icon-btn {
+  border-radius: 6px;
+  min-height: 30px;
+  min-width: 30px;
+}
+
+.passkey-chip {
+  border-radius: 6px;
+}
+</style>

--- a/src/components/modals/coresettings/UserPreferences.vue
+++ b/src/components/modals/coresettings/UserPreferences.vue
@@ -5,6 +5,7 @@
         <template v-slot:before>
           <q-tabs dense v-model="tab" vertical class="text-primary">
             <q-tab name="ui" label="User Interface" />
+            <q-tab name="security" label="Security" />
           </q-tabs>
         </template>
         <template v-slot:after>
@@ -217,6 +218,12 @@
                   />
                 </q-card-section>
               </q-tab-panel>
+
+              <q-tab-panel name="security">
+                <div class="text-subtitle2">Passkeys</div>
+                <q-separator class="q-mb-md" />
+                <PasskeyManager />
+              </q-tab-panel>
             </q-tab-panels>
 
             <q-card-section class="row items-center">
@@ -233,11 +240,20 @@
 import { openURL } from "quasar";
 import { loadingBarColors } from "@/mixins/data";
 import mixins from "@/mixins/mixins";
+import PasskeyManager from "@/components/accounts/PasskeyManager.vue";
 
 export default {
   name: "UserPreferences",
   emits: ["hide", "ok", "cancel"],
   mixins: [mixins],
+  components: { PasskeyManager },
+  props: {
+    initialTab: {
+      type: String,
+      default: "ui",
+      validator: (value) => ["ui", "security"].includes(value),
+    },
+  },
   data() {
     return {
       loadingBarColors,
@@ -245,7 +261,7 @@ export default {
       defaultAgentTblTab: "",
       clientTreeSort: "",
       url_action: null,
-      tab: "ui",
+      tab: this.initialTab,
       splitterModel: 20,
       loading_bar_color: "",
       dash_info_color: "",

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -169,11 +169,24 @@
             <q-item
               clickable
               v-ripple
-              @click="showUserPreferences"
+              @click="showUserPreferences()"
               v-close-popup
             >
               <q-item-section>
                 <q-item-label>Preferences</q-item-label>
+              </q-item-section>
+            </q-item>
+            <q-item
+              clickable
+              v-ripple
+              @click="showUserPreferences('security')"
+              v-close-popup
+            >
+              <q-item-section>
+                <q-item-label>Passkeys</q-item-label>
+              </q-item-section>
+              <q-item-section side>
+                <q-icon name="vpn_key" />
               </q-item-section>
             </q-item>
             <q-item clickable>
@@ -194,9 +207,9 @@
                       <q-item-label>Reset Password</q-item-label>
                     </q-item-section>
                   </q-item>
-                  <q-item clickable v-ripple @click="reset2FA" v-close-popup>
+                  <q-item clickable v-ripple @click="resetMFA" v-close-popup>
                     <q-item-section>
-                      <q-item-label>Reset 2FA</q-item-label>
+                      <q-item-label>Reset MFA</q-item-label>
                     </q-item-section>
                   </q-item>
                 </q-list>
@@ -235,9 +248,11 @@ import { checkWebTermPerms, openWebTerminal } from "@/api/core";
 import AlertsIcon from "@/components/AlertsIcon.vue";
 import UserPreferences from "@/components/modals/coresettings/UserPreferences.vue";
 import ResetPass from "@/components/accounts/ResetPass.vue";
+import { fetchPasskeys, isWebAuthnSupported } from "@/api/webauthn";
 
 const store = useStore();
 const $q = useQuasar();
+const auth = useAuthStore();
 
 const {
   serverCount,
@@ -247,7 +262,7 @@ const {
   daysUntilCertExpires,
 } = storeToRefs(useDashboardStore());
 
-const { displayName } = storeToRefs(useAuthStore());
+const { displayName } = storeToRefs(auth);
 
 const darkMode = computed({
   get: () => {
@@ -273,9 +288,10 @@ const latestReleaseURL = computed(() => {
     : "";
 });
 
-function showUserPreferences() {
+function showUserPreferences(initialTab: "ui" | "security" = "ui") {
   $q.dialog({
     component: UserPreferences,
+    componentProps: { initialTab },
   }).onOk(() => store.dispatch("getDashInfo"));
 }
 
@@ -285,10 +301,10 @@ function resetPassword() {
   });
 }
 
-function reset2FA() {
+function resetMFA() {
   $q.dialog({
-    title: "Reset 2FA",
-    message: "Are you sure you would like to reset your 2FA token?",
+    title: "Reset MFA",
+    message: "This removes your TOTP secret and enrolled passkeys.",
     cancel: true,
     persistent: true,
   }).onOk(async () => {
@@ -296,6 +312,34 @@ function reset2FA() {
       const ret = await resetTwoFactor();
       notifySuccess(ret, 3000);
     } catch {}
+  });
+}
+
+async function maybePromptPasskeyEnrollment() {
+  if (!auth.consumePasskeyEnrollmentPrompt() || !isWebAuthnSupported()) return;
+
+  try {
+    const passkeys = await fetchPasskeys();
+    if (passkeys.length > 0) return;
+  } catch {
+    return;
+  }
+
+  $q.notify({
+    type: "info",
+    message: "Passkeys are now the preferred sign-in method.",
+    caption:
+      "You can enroll one now, or any time from Preferences > Security > Passkeys.",
+    timeout: 12000,
+    multiLine: true,
+    actions: [
+      {
+        label: "Open Security",
+        color: "white",
+        handler: () => showUserPreferences("security"),
+      },
+      { label: "Later", color: "white" },
+    ],
   });
 }
 
@@ -308,7 +352,7 @@ async function openWebTerm() {
       openWebTerminal();
     }
   } catch (e) {
-    console.error(e);
+    notifyError(e instanceof Error ? e.message : "Unable to open web terminal");
   }
 }
 
@@ -337,6 +381,7 @@ function livePoll() {
 onMounted(() => {
   store.dispatch("getDashInfo");
   store.dispatch("checkVer");
+  maybePromptPasskeyEnrollment();
   livePoll();
 });
 

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -2,6 +2,7 @@ import { defineStore } from "pinia";
 import { useStorage } from "@vueuse/core";
 
 import axios from "axios";
+import { completePasskeyLogin } from "@/api/webauthn";
 
 interface CheckCredentialsRequest {
   username: string;
@@ -15,9 +16,11 @@ interface LoginRequest {
 }
 
 interface CheckCredentialsResponse {
-  token: string;
-  username: string;
+  token?: string;
+  username?: string;
+  name?: string | null;
   totp?: boolean;
+  passkey?: boolean;
 }
 
 interface TOTPSetupResponse {
@@ -33,6 +36,7 @@ export const useAuthStore = defineStore("auth", {
     ssoLoginProvider: useStorage("sso_provider", null),
     provider_id: useStorage("provider_id", null),
     next: useStorage("next", null),
+    passkeyEnrollmentPrompt: false,
   }),
   getters: {
     loggedIn: (state) => {
@@ -48,7 +52,7 @@ export const useAuthStore = defineStore("auth", {
     ): Promise<CheckCredentialsResponse> {
       const { data } = await axios.post("/v2/checkcreds/", credentials);
 
-      if (!data.totp) {
+      if (!data.totp && !data.passkey) {
         this.token = data.token;
         this.username = data.username;
         this.name = data.name;
@@ -64,6 +68,23 @@ export const useAuthStore = defineStore("auth", {
 
       return data;
     },
+    async loginWithPasskey(credential: Record<string, unknown>) {
+      const data = await completePasskeyLogin(credential);
+      this.username = data.username;
+      this.name = data.name;
+      this.token = data.token;
+      this.ssoLoginProvider = null;
+
+      return data;
+    },
+    requestPasskeyEnrollmentPrompt() {
+      this.passkeyEnrollmentPrompt = true;
+    },
+    consumePasskeyEnrollmentPrompt() {
+      const shouldPrompt = this.passkeyEnrollmentPrompt;
+      this.passkeyEnrollmentPrompt = false;
+      return shouldPrompt;
+    },
     async logout() {
       if (this.token !== null) {
         try {
@@ -75,6 +96,7 @@ export const useAuthStore = defineStore("auth", {
       this.name = null;
       this.ssoLoginProvider = null;
       this.provider_id = null;
+      this.passkeyEnrollmentPrompt = false;
     },
     async setupTotp(): Promise<TOTPSetupResponse | false> {
       const { data } = await axios.post("/accounts/users/setup_totp/");

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -103,6 +103,13 @@
 
               <q-card-actions align="right" class="text-primary">
                 <q-btn flat label="Cancel" v-close-popup />
+                <q-btn
+                  v-if="hasPasskey"
+                  flat
+                  label="Use Passkey"
+                  type="button"
+                  @click="onPasskeySubmit"
+                />
                 <q-btn flat label="Submit" type="submit" />
               </q-card-actions>
             </q-form>
@@ -118,6 +125,12 @@ import { ref, reactive, onMounted } from "vue";
 import { type QForm, useQuasar } from "quasar";
 import { useAuthStore } from "@/stores/auth";
 import { useRouter } from "vue-router";
+import {
+  beginPasskeyLogin,
+  credentialToJSON,
+  getPasskeyAssertion,
+} from "@/api/webauthn";
+import { notifyError } from "@/utils/notify";
 import {
   openSSOProviderRedirect,
   getSSOConfig,
@@ -141,35 +154,76 @@ const formToken = ref<QForm | null>(null);
 const credentials = reactive({ username: "", password: "" });
 const twofactor = ref("");
 const prompt = ref(false);
+const hasTotp = ref(false);
+const hasPasskey = ref(false);
 const showPassword = ref(true);
 const ssoProviders = ref([] as SSOProviderConfig[]);
 
+function errorMessage(error: unknown, fallback: string) {
+  return error instanceof Error ? error.message : fallback;
+}
+
 async function checkCreds() {
   try {
-    const { totp } = await auth.checkCredentials(credentials);
+    const { totp, passkey } = await auth.checkCredentials(credentials);
+    hasTotp.value = !!totp;
+    hasPasskey.value = !!passkey;
 
-    if (!totp) {
-      router.push({ name: "TOTPSetup" });
-    } else {
+    if (passkey) {
+      await onPasskeySubmit();
+    } else if (totp) {
       twofactor.value = "";
       prompt.value = true;
+    } else {
+      router.push({ name: "TOTPSetup" });
     }
   } catch (err) {
-    console.error(err);
+    notifyError(errorMessage(err, "Login failed"), 3500);
+  }
+}
+
+async function routeAfterLogin() {
+  if (auth.next) {
+    router.push(auth.next);
+    auth.next = null;
+  } else {
+    router.push({ name: "Dashboard" });
+  }
+}
+
+async function onPasskeySubmit() {
+  prompt.value = false;
+  $q.loading.show();
+  try {
+    const options = await beginPasskeyLogin();
+    const credential = await getPasskeyAssertion(options);
+    await auth.loginWithPasskey(credentialToJSON(credential));
+    form.value?.reset();
+    formToken.value?.reset();
+    await routeAfterLogin();
+  } catch (err) {
+    if (hasTotp.value) {
+      twofactor.value = "";
+      prompt.value = true;
+    } else {
+      const message =
+        err instanceof Error ? err.message : "Passkey verification failed";
+      notifyError(message, 3500);
+    }
+  } finally {
+    $q.loading.hide();
   }
 }
 
 async function onSubmit() {
   try {
     await auth.login({ ...credentials, twofactor: twofactor.value });
-    if (auth.next) {
-      router.push(auth.next);
-      auth.next = null;
-    } else {
-      router.push({ name: "Dashboard" });
+    if (!hasPasskey.value) {
+      auth.requestPasskeyEnrollmentPrompt();
     }
+    await routeAfterLogin();
   } catch (err) {
-    console.error(err);
+    notifyError(errorMessage(err, "Login failed"), 3500);
   } finally {
     form.value?.reset();
     formToken.value?.reset();
@@ -181,8 +235,8 @@ onMounted(async () => {
   try {
     const result = await getSSOConfig();
     ssoProviders.value = result.data.socialaccount.providers;
-  } catch (e) {
-    console.error(e);
+  } catch {
+    ssoProviders.value = [];
   }
 });
 </script>

--- a/tests/passkey-ui.test.mjs
+++ b/tests/passkey-ui.test.mjs
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+import { parse } from "@vue/compiler-sfc";
+
+function descriptor(path) {
+  const source = readFileSync(new URL(`../${path}`, import.meta.url), "utf8");
+  return parse(source, { filename: path }).descriptor;
+}
+
+function template(path) {
+  return descriptor(path).template?.content ?? "";
+}
+
+function script(path) {
+  const sfc = descriptor(path);
+  return `${sfc.script?.content ?? ""}\n${sfc.scriptSetup?.content ?? ""}`;
+}
+
+function style(path) {
+  return descriptor(path)
+    .styles.map((entry) => entry.content)
+    .join("\n");
+}
+
+test("preferences passkey enrollment actions are explicit and ordered", () => {
+  const tpl = template("src/components/accounts/PasskeyManager.vue");
+  const js = script("src/components/accounts/PasskeyManager.vue");
+
+  assert.equal(tpl.includes(["More", "Options"].join(" ")), false);
+  assert.match(tpl, /<q-btn-dropdown[\s\S]*label="Other"/);
+  assert.match(tpl, /<q-item-section>Browser Choice<\/q-item-section>/);
+  assert.match(tpl, /<q-item-section>Security Key<\/q-item-section>/);
+  assert.match(tpl, /label="Phone"/);
+  assert.match(tpl, /label="This Device"/);
+
+  const otherIndex = tpl.indexOf('label="Other"');
+  const phoneIndex = tpl.indexOf('label="Phone"');
+  const deviceIndex = tpl.indexOf('label="This Device"');
+  assert.ok(otherIndex < phoneIndex);
+  assert.ok(phoneIndex < deviceIndex);
+
+  assert.match(js, /label:\s*"Passkey name"/);
+  assert.match(js, /ok:\s*\{\s*label:\s*"Continue"\s*\}/);
+  assert.match(js, /defaultName:\s*"This device"/);
+  assert.match(js, /beginPasskeyRegistration\(option\.attachment\)/);
+});
+
+test("passkey transport chips use rounded rectangle styling", () => {
+  for (const path of [
+    "src/components/accounts/PasskeyManager.vue",
+    "src/components/accounts/UserPasskeysTable.vue",
+  ]) {
+    const tpl = template(path);
+    const css = style(path);
+
+    assert.match(tpl, /<q-chip[\s\S]*square[\s\S]*class="passkey-chip"/);
+    assert.match(css, /\.passkey-chip\s*\{[\s\S]*border-radius:\s*6px;/);
+  }
+});
+
+test("user administration MFA markers stay compact", () => {
+  const tpl = template("src/components/AdminManager.vue");
+  const css = style("src/components/AdminManager.vue");
+
+  assert.match(tpl, /class="mfa-chip"[\s\S]*>TOTP/);
+  assert.match(tpl, /class="mfa-chip"[\s\S]*icon-right="vpn_key"/);
+  assert.equal(tpl.includes("passkey_last_used_at"), false);
+  assert.match(css, /\.mfa-chip\s*\{[\s\S]*border-radius:\s*6px;/);
+});
+
+test("user menu passkey shortcut puts the key icon on the right", () => {
+  const tpl = template("src/layouts/MainLayout.vue");
+  const labelIndex = tpl.indexOf("<q-item-label>Passkeys</q-item-label>");
+  const iconIndex = tpl.indexOf("<q-item-section side>", labelIndex);
+  const nextAccountIndex = tpl.indexOf("<q-item clickable>", labelIndex + 1);
+
+  assert.ok(labelIndex > -1);
+  assert.ok(iconIndex > labelIndex);
+  assert.ok(nextAccountIndex === -1 || iconIndex < nextAccountIndex);
+});
+
+test("login and preferences expose passkey-first fallback surfaces", () => {
+  const loginTpl = template("src/views/LoginView.vue");
+  const loginJs = script("src/views/LoginView.vue");
+  const preferencesTpl = template(
+    "src/components/modals/coresettings/UserPreferences.vue",
+  );
+
+  assert.match(loginTpl, /label="Use Passkey"/);
+  assert.match(loginJs, /if \(passkey\) \{\s*await onPasskeySubmit\(\);/);
+  assert.match(loginJs, /if \(hasTotp\.value\) \{[\s\S]*prompt\.value = true;/);
+  assert.match(loginJs, /auth\.requestPasskeyEnrollmentPrompt\(\)/);
+  assert.match(preferencesTpl, /<q-tab name="security" label="Security"/);
+  assert.match(preferencesTpl, /<PasskeyManager \/>/);
+});


### PR DESCRIPTION
## Summary

Adds the UI for passkey-first sign-in and passkey management.

Users can sign in with a passkey when one is enrolled, use TOTP as the fallback path, and manage multiple passkeys from Preferences. User administration now shows compact MFA markers and includes passkey audit/reset controls.

Companion backend PR: https://github.com/amidaware/tacticalrmm/pull/2507

## User experience

- Adds passkey sign-in alongside the existing TOTP flow.
- Prompts users after TOTP sign-in that passkeys can be enrolled from the user menu.
- Adds Preferences > Security > Passkeys with enrollment, rename, delete, and refresh actions.
- Supports separate enrollment choices for this device, phone, browser choice, and security key.
- Uses local-device passkey options that work with platform authenticators such as Touch ID.
- Keeps TOTP visible as the fallback method rather than replacing it.
- Adds user administration passkey visibility and reset controls with compact rounded-rectangle markers.

## Validation

- Ran `npm test`.
- Ran `npm run lint`.
- Ran `npm run build`.
- Built and smoke-tested the frontend bundle through nginx on an upgraded Tactical RMM 1.5.1 validation VM.
